### PR TITLE
Revise injection to work without storage

### DIFF
--- a/src/sniffForMapML.js
+++ b/src/sniffForMapML.js
@@ -1,13 +1,13 @@
 function sendMessage(message) {
     chrome.storage.local.get("options", function (items) {
-        let renderMap = items.options ? items.options.renderMap : false;
+        const renderMap = items.options ? items.options.renderMap : false;
         if (renderMap) chrome.runtime.sendMessage(message);
     });
 }
 
-let mapml = document.querySelector("mapml-");
+const mapml = document.querySelector("mapml-");
 if(mapml) {
-    sendMessage("xml");
+    sendMessage(document.contentType === "text/html" ? "html" : "xml");
 } else if(document.contentType === "text/mapml"){
     sendMessage("mapml");
 }


### PR DESCRIPTION
This simplifies background a bit by avoiding `chrome.storage` and eliminates an extra page reload if document initially had the proper Content-Type `text/html`.